### PR TITLE
Hide main window on close to keep the app state

### DIFF
--- a/Chital.xcodeproj/project.pbxproj
+++ b/Chital.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4C504D7B2CBF422D007E8796 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C504D7A2CBF422C007E8796 /* AppDelegate.swift */; };
 		85156A3E2CA6BFD20061ED78 /* ChitalApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85156A3D2CA6BFD20061ED78 /* ChitalApp.swift */; };
 		85156A442CA6BFD30061ED78 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85156A432CA6BFD30061ED78 /* Assets.xcassets */; };
 		85156A472CA6BFD30061ED78 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85156A462CA6BFD30061ED78 /* Preview Assets.xcassets */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4C504D7A2CBF422C007E8796 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		85156A3A2CA6BFD20061ED78 /* Chital.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chital.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		85156A3D2CA6BFD20061ED78 /* ChitalApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChitalApp.swift; sourceTree = "<group>"; };
 		85156A432CA6BFD30061ED78 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -68,6 +70,7 @@
 		85156A3C2CA6BFD20061ED78 /* Chital */ = {
 			isa = PBXGroup;
 			children = (
+				4C504D7A2CBF422C007E8796 /* AppDelegate.swift */,
 				85156A3D2CA6BFD20061ED78 /* ChitalApp.swift */,
 				85156A502CA6C0210061ED78 /* AppConstants.swift */,
 				85156A4F2CA6C0210061ED78 /* ChatBubbleView.swift */,
@@ -176,6 +179,7 @@
 				85156A562CA6C0210061ED78 /* ContentView.swift in Sources */,
 				85156A3E2CA6BFD20061ED78 /* ChitalApp.swift in Sources */,
 				85156A582CA6C0210061ED78 /* AppConstants.swift in Sources */,
+				4C504D7B2CBF422D007E8796 /* AppDelegate.swift in Sources */,
 				85156A5C2CA6C0210061ED78 /* ChatModels.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Chital/AppDelegate.swift
+++ b/Chital/AppDelegate.swift
@@ -1,0 +1,21 @@
+//
+//  AppDelegate.swift
+//  Chital
+//
+//  Created by Alex Titarenko on 10/15/24.
+//
+
+import Foundation
+import SwiftUI
+
+class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let mainWindow = NSApp.windows[0]
+        mainWindow.delegate = self
+    }
+    
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        NSApp.hide(nil)
+        return false
+    }
+}

--- a/Chital/ChitalApp.swift
+++ b/Chital/ChitalApp.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 @main
 struct ChitalApp: App {
+    @NSApplicationDelegateAdaptor() private var applicationDelegate: AppDelegate
+    
     var container: ModelContainer = {
         let schema = Schema([
             ChatThread.self,


### PR DESCRIPTION
The typical behavior for applications on Mac is to hide the window on close. In this case, when you click on the app from the doc, it will reappear in the same state as before.