### PR TITLE
Update id to use private(set) for future Swift 6 compatibility with @Model macro

### DIFF
--- a/Chital/ChatModels.swift
+++ b/Chital/ChatModels.swift
@@ -3,7 +3,7 @@ import SwiftData
 
 @Model
 final class ChatThread: Identifiable {
-    let id: UUID
+    private(set) var id: UUID
     var createdAt: Date
     var title: String
     var hasReceivedFirstMessage: Bool
@@ -23,7 +23,7 @@ final class ChatThread: Identifiable {
 
 @Model
 final class ChatMessage: Identifiable {
-    let id: UUID
+    private(set) var id: UUID
     var text: String
     var isUser: Bool
     var createdAt: Date


### PR DESCRIPTION
Make `id` in `ChatModel` mutable internally with `private(set)` to ensure compatibility with @Model macro in Swift 6 while preserving external immutability. This allows the property to support synthesized accessors and internal updates if required, without exposing mutability to external consumers.


Before
![image](https://github.com/user-attachments/assets/41bcd81b-463b-4c1f-a1b5-0a884b80821d)

After
![image](https://github.com/user-attachments/assets/277de93e-d59b-49cd-8027-52e46be7b4fa)


[Stackover link](https://stackoverflow.com/questions/79003642/swiftdata-model-object-warning-cannot-expand-accessors-on-variable-declared-wi) where I got the idea for the solution.